### PR TITLE
chore: Add `arrow-tools` crate for shared logic between utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-tools"
+version = "0.0.1"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +468,7 @@ version = "0.8.1"
 dependencies = [
  "arrow",
  "arrow-schema",
+ "arrow-tools",
  "clap",
  "serde_json",
 ]
@@ -474,6 +479,7 @@ version = "0.8.1"
 dependencies = [
  "arrow",
  "arrow-schema",
+ "arrow-tools",
  "clap",
  "parquet",
  "serde_json",
@@ -701,6 +707,7 @@ version = "0.8.1"
 dependencies = [
  "arrow",
  "arrow-schema",
+ "arrow-tools",
  "clap",
  "serde_json",
 ]
@@ -711,6 +718,7 @@ version = "0.8.1"
 dependencies = [
  "arrow",
  "arrow-schema",
+ "arrow-tools",
  "clap",
  "parquet",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "crates/csv2parquet",
   "crates/json2arrow",
   "crates/json2parquet",
+  "crates/arrow-tools"
 ]
 
 [workspace.metadata.release]

--- a/crates/arrow-tools/Cargo.toml
+++ b/crates/arrow-tools/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "arrow-tools"
+version = "0.0.1"
+edition = "2021"
+
+
+[dependencies]

--- a/crates/arrow-tools/Readme.md
+++ b/crates/arrow-tools/Readme.md
@@ -1,0 +1,2 @@
+# Arrow-tools
+This crate serves a general util library to go along with all of the crates within the arrow-tools suite.

--- a/crates/arrow-tools/src/lib.rs
+++ b/crates/arrow-tools/src/lib.rs
@@ -1,0 +1,5 @@
+//! # Arrow-tools
+//! This crate serves a general util library to go along
+//! with all of the crates within the arrow-tools suite.
+
+pub fn a_test_fn() {}

--- a/crates/arrow-tools/src/lib.rs
+++ b/crates/arrow-tools/src/lib.rs
@@ -1,5 +1,3 @@
 //! # Arrow-tools
 //! This crate serves a general util library to go along
 //! with all of the crates within the arrow-tools suite.
-
-pub fn a_test_fn() {}

--- a/crates/csv2arrow/Cargo.toml
+++ b/crates/csv2arrow/Cargo.toml
@@ -14,3 +14,4 @@ arrow = "34.0.0"
 arrow-schema = { version = "34.0.0", features = ["serde"] }
 serde_json = "1.0.91"
 clap = { version = "4.1.8", features = ["derive"] }
+arrow-tools = { path = "../arrow-tools" }

--- a/crates/csv2parquet/Cargo.toml
+++ b/crates/csv2parquet/Cargo.toml
@@ -15,3 +15,4 @@ arrow = "34.0.0"
 arrow-schema = { version = "34.0.0", features = ["serde"] }
 serde_json = "1.0.91"
 clap = { version = "4.1.8", features = ["derive"] }
+arrow-tools = { path = "../arrow-tools" }

--- a/crates/json2arrow/Cargo.toml
+++ b/crates/json2arrow/Cargo.toml
@@ -14,3 +14,4 @@ arrow = "34.0.0"
 arrow-schema = { version = "34.0.0", features = ["serde"] }
 serde_json = "1.0.91"
 clap = { version = "4.1.8", features = ["derive"] }
+arrow-tools = { path = "../arrow-tools" }

--- a/crates/json2parquet/Cargo.toml
+++ b/crates/json2parquet/Cargo.toml
@@ -15,3 +15,4 @@ arrow = "34.0.0"
 arrow-schema = { version = "34.0.0", features = ["serde"] }
 serde_json = "1.0.91"
 clap = { version = "4.1.8", features = ["derive"] }
+arrow-tools = { path = "../arrow-tools" }


### PR DESCRIPTION
For the growth of this project it is useful to have a library layer to store shared logic. #10 is an example where having this library crate would be particularly useful.

This PR adds a new crate library `arrow-tools` to the workspace, such that it could be used in any other crate in the workspace via:
```rust
use arrow_tools::{my_fn};
```