### PR TITLE
docs: add documentation for input and output piping

### DIFF
--- a/crates/csv2arrow/Readme.md
+++ b/crates/csv2arrow/Readme.md
@@ -53,3 +53,5 @@ Options:
 ```
 
 The --schema-file option uses the same file format as --dry and --print-schema.
+
+For examples of usage see [csv2parquet examples](https://github.com/domoritz/arrow-tools/tree/main/crates/csv2parquet#examples) as both programs share a similar interface.

--- a/crates/csv2parquet/Readme.md
+++ b/crates/csv2parquet/Readme.md
@@ -127,3 +127,9 @@ Then add the schema-file `schema.json` in the command:
 ```
 csv2parquet --header false --schema-file schema.json <CSV> <PARQUET>
 ```
+
+### Convert streams piping from standard input to standard output
+This technique can prevent you from writing large files to disk entirely.
+```bash
+curl <FILE_URL> | csv2parquet /dev/stdin /dev/stdout | aws s3 cp - <S3_DESTINATION>
+```

--- a/crates/json2arrow/Readme.md
+++ b/crates/json2arrow/Readme.md
@@ -50,6 +50,8 @@ Options:
 
 The --schema-file option uses the same file format as --dry and --print-schema.
 
+For examples of usage see [csv2parquet examples](https://github.com/domoritz/arrow-tools/tree/main/crates/csv2parquet#examples) as both programs share a similar interface.
+
 ## Limitations
 
 Since we use the Arrow JSON loader, we are limited to what it supports. Right now, it supports JSON line-delimited files.

--- a/crates/json2parquet/Readme.md
+++ b/crates/json2parquet/Readme.md
@@ -70,6 +70,8 @@ Options:
 
 The --schema-file option uses the same file format as --dry and --print-schema.
 
+For examples of usage see [csv2parquet examples](https://github.com/domoritz/arrow-tools/tree/main/crates/csv2parquet#examples) as both programs share a similar interface. 
+
 ## Limitations
 
 Since we use the Arrow JSON loader, we are limited to what it supports. Right now, it supports JSON line-delimited files.


### PR DESCRIPTION
Minor update to documentation to include info re: piping stdin and stdout

Related to issue #57 