### PR TITLE
Build targets for musl (works on Amazon Linux, Alpine, etc.)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ cargo-dist-version = "0.3.1"
 # CI backends to support (see 'cargo dist generate-ci')
 ci = ["github"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
+targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
 
 # The profile that 'cargo dist' will build with
 [profile.dist]


### PR DESCRIPTION
We would like to be able to run arrow-tools on certain Docker images based on Amazon Linux. Rust builds do not work there when based on glibc (as it requires a later version), and instead, musl should be used.

I've also included an ARM target, which is becoming increasingly commonly used. This allows us to run arrow-tools on Graviton processors as well.

Admittedly, this is a somewhat selfish PR :), but it's our hope that it will also benefit others who want to use these super useful utilities on these platforms.